### PR TITLE
Add NavItem component and nav-item tokens for UUI-style menu active s…

### DIFF
--- a/src/components/NavItem.tsx
+++ b/src/components/NavItem.tsx
@@ -1,0 +1,62 @@
+import type { ReactNode } from 'react';
+import { cx } from '@/utils/cx';
+
+/**
+ * Returns the CSS class string for a sidebar/menu nav item.
+ * Use with NavLink's className prop for router-aware active state:
+ *
+ *   <NavLink to={path} className={({ isActive }) => navItemClass(isActive)}>
+ *     Label
+ *   </NavLink>
+ *
+ * Or pass isActive directly:
+ *
+ *   <NavItem isActive={selected === id}>Label</NavItem>
+ */
+export function navItemClass(isActive: boolean, className?: string) {
+  return cx(
+    // Layout & shape
+    'block w-full rounded-lg px-3 py-2 text-sm text-left transition duration-100 ease-linear',
+    // Active state
+    isActive
+      ? 'bg-[var(--nav-item-active)] text-[var(--text-primary)] font-medium'
+      : 'text-[var(--text-tertiary)] hover:bg-[var(--nav-item-hover)] hover:text-[var(--text-secondary)]',
+    className,
+  );
+}
+
+interface NavItemProps {
+  /** Whether this item is currently selected/active */
+  isActive?: boolean;
+  /** Click handler */
+  onClick?: () => void;
+  /** Additional class names */
+  className?: string;
+  children: ReactNode;
+}
+
+/**
+ * NavItem — styled sidebar/menu navigation item.
+ *
+ * Use this as the standard pattern for any navigation menu — sidebar,
+ * drawer, dropdown, etc. Provides the UUI-style active and hover states:
+ * - Active: solid rounded background (bg-[var(--nav-item-active)])
+ * - Hover:  subtle tinted background (bg-[var(--nav-item-hover)])
+ * - Border radius: 8px (rounded-lg)
+ *
+ * For router-aware active state via NavLink, use `navItemClass()` instead:
+ *
+ *   import { navItemClass } from '@/components/NavItem';
+ *   <NavLink to={path} className={({ isActive }) => navItemClass(isActive)} />
+ */
+export function NavItem({ isActive = false, onClick, className, children }: NavItemProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={navItemClass(isActive, className)}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/docs/layout/sidebar.tsx
+++ b/src/docs/layout/sidebar.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 import { ChevronUp } from '@untitledui/icons';
 import { LogoHologram } from '@/components/logos/Logo';
+import { navItemClass } from '@/components/NavItem';
 import { useTheme } from '@/providers/theme-provider';
 
 const NAV = [
@@ -41,7 +42,6 @@ const NAV = [
 
 export function Sidebar() {
   const { theme, setTheme } = useTheme();
-  const location = useLocation();
   const [openSections, setOpenSections] = useState<Record<string, boolean>>(
     Object.fromEntries(NAV.map((s) => [s.group, true]))
   );
@@ -87,12 +87,12 @@ export function Sidebar() {
 
           return (
             <div key={section.group}>
-              {/* Dotted divider between sections */}
+              {/* Dotted divider between sections — not full width, matches UUI */}
               {index > 0 && (
                 <div
                   style={{
-                    borderTop: '1px dotted var(--border-secondary)',
-                    margin: '12px 16px',
+                    borderTop: '1px dotted var(--border-default)',
+                    margin: '10px 16px 14px',
                   }}
                 />
               )}
@@ -105,7 +105,7 @@ export function Sidebar() {
                   alignItems: 'center',
                   justifyContent: 'space-between',
                   width: '100%',
-                  padding: '6px 16px',
+                  padding: '4px 16px 8px',
                   fontSize: 11,
                   fontWeight: 600,
                   letterSpacing: '0.08em',
@@ -115,7 +115,6 @@ export function Sidebar() {
                   border: 'none',
                   cursor: 'pointer',
                   fontFamily: 'inherit',
-                  marginBottom: 4,
                 }}
               >
                 {section.group}
@@ -133,42 +132,16 @@ export function Sidebar() {
 
               {/* Nav items */}
               {isOpen && (
-                <div>
-                  {section.items.map((item) => {
-                    const isActive = location.pathname === item.path;
-                    return (
-                      <NavLink
-                        key={item.path}
-                        to={item.path}
-                        style={{
-                          display: 'block',
-                          margin: '1px 8px',
-                          padding: '7px 12px',
-                          fontSize: 14,
-                          fontWeight: isActive ? 500 : 400,
-                          color: isActive ? 'var(--text-primary)' : 'var(--text-tertiary)',
-                          textDecoration: 'none',
-                          borderRadius: 6,
-                          background: isActive ? 'var(--bg-active)' : 'transparent',
-                          transition: 'background 0.1s, color 0.1s',
-                        }}
-                        onMouseEnter={(e) => {
-                          if (!isActive) {
-                            (e.currentTarget as HTMLElement).style.background = 'var(--bg-primary_hover)';
-                            (e.currentTarget as HTMLElement).style.color = 'var(--text-secondary)';
-                          }
-                        }}
-                        onMouseLeave={(e) => {
-                          if (!isActive) {
-                            (e.currentTarget as HTMLElement).style.background = 'transparent';
-                            (e.currentTarget as HTMLElement).style.color = 'var(--text-tertiary)';
-                          }
-                        }}
-                      >
-                        {item.label}
-                      </NavLink>
-                    );
-                  })}
+                <div style={{ padding: '0 8px' }}>
+                  {section.items.map((item) => (
+                    <NavLink
+                      key={item.path}
+                      to={item.path}
+                      className={({ isActive }) => navItemClass(isActive)}
+                    >
+                      {item.label}
+                    </NavLink>
+                  ))}
                 </div>
               )}
             </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { Logo, LogoHologram, LogoWhite, LogoBlack } from "@/components/logos/Log
 
 // Components
 export { Avatar } from "@/components/Avatar";
+export { NavItem, navItemClass } from "@/components/NavItem";
 export { Badge } from "@/components/Badge";
 export { BadgeGroup } from "@/components/BadgeGroup";
 export { Button } from "@/components/Button";

--- a/src/tokens/tokens.css
+++ b/src/tokens/tokens.css
@@ -117,6 +117,10 @@
     --bg-accent-subtle:    var(--blurple-100);
     --bg-accent-default:   var(--blurple-600);
 
+    /* Navigation items */
+    --nav-item-active:     var(--zinc-200);
+    --nav-item-hover:      var(--zinc-100);
+
     /* Text */
     --text-primary:        var(--zinc-950);
     --text-secondary:      var(--zinc-700);
@@ -266,6 +270,10 @@
     --bg-accent-subtle:    rgba(104, 61, 238, 0.15);
     --bg-accent-default:   var(--blurple-400);
 
+    /* Navigation items */
+    --nav-item-active:     var(--zinc-800);
+    --nav-item-hover:      var(--zinc-900);
+
     --text-primary:        var(--zinc-50);
     --text-secondary:      var(--zinc-300);
     --text-tertiary:       var(--zinc-500);
@@ -374,6 +382,10 @@
     --bg-brand-default:    var(--graffiti-500);
     --bg-brand-hover:      var(--graffiti-700);
     --bg-accent-default:   var(--blurple-600);
+
+    /* Navigation items */
+    --nav-item-active:     var(--zinc-200);
+    --nav-item-hover:      var(--zinc-100);
 
     --text-primary:        var(--zinc-950);
     --text-secondary:      var(--zinc-700);


### PR DESCRIPTION
…tates

- Add --nav-item-active and --nav-item-hover tokens to all three theme sections in tokens.css (light: zinc-200/100, dark: zinc-800/900)
- Create NavItem component with navItemClass() utility for router-aware active states via NavLink className prop
- Update sidebar to use navItemClass() — removes inline hover handlers, removes green left-border active state, adds rounded bg-fill active style
- Export NavItem and navItemClass from index.ts as the standard menu pattern

https://claude.ai/code/session_01VEuW6w8K2c57bC9tLPrLhy